### PR TITLE
Make use of general CornerPlotting package

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.3.3"
 
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+CornerPlotting = "4a808bcd-0da0-4a1c-a768-2071018375da"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [compat]
 CairoMakie = "0.11, 0.12"
+CornerPlotting = "0.1"
 Distributions = "0.25"
 HDF5 = "0.17"
 MathTeXEngine = "0.6"

--- a/examples/plot_results_vfts243.jl
+++ b/examples/plot_results_vfts243.jl
@@ -9,7 +9,7 @@ using CairoMakie
 using SideKicks
 using Distributions
 
-results, observations, priors, metadata = SideKicks.ExtractResults("vfts243_results.hdf5", transpose_results=true)
+results, observations, priors, metadata = SideKicks.ExtractResults("vfts243_results.hdf5")
 
 ##
 #=
@@ -31,7 +31,8 @@ cp = create_corner_plot(results, plotting_props_obs_check,
             :e_f => Normal(0.017,0.012),
             :K1 => Normal(81.4, 1.3),
             :P_f => Normal(10.4031, 0.01)
-        )
+        ),
+    nbins = 20, nbins_contour = 10
     )
 save("vfts243_observables.png", cp.fig)
 
@@ -45,25 +46,22 @@ consequences for explosion itself.
 
 plotting_props = SideKicks.createPlottingProps([
     [:m2,     m_sun,    [0,25],         L"M_2  \;[M_{\odot}]"],
-    [:dm2,    m_sun,    [0, 4],        L"ΔM_2  \;[M_{\odot}]"],
+    [:dm2,    m_sun,    [0, 6],        L"ΔM_2  \;[M_{\odot}]"],
     [:P,      day,      [8,12],        L"P  \;[\mathrm{days}]"],
     [:vkick, km_per_s,  [0,50],         L"v_{kick}  \;[\mathrm{km s}^{-1}]"],
     [:vsys,  km_per_s, [0,50],        L"v_{\mathrm{sys}} \;[\mathrm{km s}^{-1}]"],
 ])
 
-f = create_corner_plot(results, plotting_props,
-    tickfontsize=10 ,
-    xticklabelrotation=pi/4, 
+cp = create_corner_plot(results, plotting_props,
     show_CIs=true,
     supertitle="VFTS 243 - derived quantities",
     fraction_1D = 0.9,
+    nbins = 20, nbins_contour = 10
     )
 
-println("Temporary issue with docs not showing derived quantities")
+save("vfts243_derived.png", cp.fig)
 
-save("vfts243_derived.pdf", f)
-
-f
+cp.fig
 
 ##
 #=

--- a/examples/plot_results_vfts243.jl
+++ b/examples/plot_results_vfts243.jl
@@ -7,8 +7,9 @@ the previous example. We start by loading up
 
 using CairoMakie
 using SideKicks
+using Distributions
 
-results, observations, priors, metadata = SideKicks.ExtractResults("vfts243_results.hdf5")
+results, observations, priors, metadata = SideKicks.ExtractResults("vfts243_results.hdf5", transpose_results=true)
 
 ##
 #=
@@ -23,12 +24,18 @@ plotting_props_obs_check = SideKicks.createPlottingProps([
     [:K1,    km_per_s, [77,90],        L"K_1  \;[\mathrm{km s}^{-1}]"],
 ])
 
-f = create_corner_plot(results, plotting_props_obs_check,
+cp = create_corner_plot(results, plotting_props_obs_check,
     supertitle="VFTS 243 - observables",
+    dists_to_plot = Dict(
+            :m1_f => Normal(25.0,2.3),
+            :e_f => Normal(0.017,0.012),
+            :K1 => Normal(81.4, 1.3),
+            :P_f => Normal(10.4031, 0.01)
+        )
     )
-save("vfts243_observables.png", f)
+save("vfts243_observables.png", cp.fig)
 
-f
+cp.fig
 
 ##
 #=

--- a/examples/run_inference_vfts243.jl
+++ b/examples/run_inference_vfts243.jl
@@ -57,9 +57,9 @@ kick_mcmc = SideKicks.KickMCMC(
         which_model = :general,
         observations = obs,
         priors = priors,
-        nuts_warmup_count = 200,
+        nuts_warmup_count = 500,
         nuts_acceptance_rate = 0.8,
-        nsamples = 200,
+        nsamples = 1000,
         nchains = 4)
 
 ##

--- a/src/CornerPlots.jl
+++ b/src/CornerPlots.jl
@@ -78,7 +78,7 @@ function create_corner_plot(results, plotting_props;
         fig=Figure(), supertitle=nothing,
         fraction_1D=0.9, fractions_2D=[0.9], 
         show_CIs=true, nbins=100, nbins_contour=30,
-        supertitlefontsize=30, use_corner_plotting_theme=true)
+        supertitlefontsize=25, use_corner_plotting_theme=true)
  
     # TODO: Is there a way to add the priors? They are often modified
     # versions of the plotted parameters, this may be very non-trivial
@@ -110,7 +110,10 @@ function create_corner_plot(results, plotting_props;
     if use_corner_plotting_theme
         set_theme!(CornerPlotting.default_theme())
     end
-    corner_plot = CornerPlotting.CornerPlot(results,props;labels=names,scaling=units)
+    f = Figure(figure_padding=30)
+    corner_plot = CornerPlotting.CornerPlot(results,props;
+                                    fig=f,ranges=ranges,labels=names,scaling=units, 
+                                    nbins=nbins, nbins_contour=nbins_contour)
 
     if !isnothing(dists_to_plot)
         for name in keys(dists_to_plot)

--- a/src/KickMCMC.jl
+++ b/src/KickMCMC.jl
@@ -58,26 +58,25 @@ function KickMCMC(; which_model, observations::Tuple{Observations, String}, prio
     results = Dict() 
     for i_prop in eachindex(props_cauchy)                                                    
         prop = props_cauchy[i_prop]
-        chain_array = zeros(Float64, nchains, nsamples) # Matrix (nchain x nsample)
+        chain_array = zeros(Float64, nsamples, nchains) # Matrix (nsample x nchain)
         for i_chain in 1:nchains
             for i_sample in 1:nsamples
-                chain_array[i_chain, i_sample] = output_values[i_sample, i_chain][i_prop]
+                chain_array[i_sample, i_chain] .= output_values[i_sample, i_chain][i_prop]
             end
         end
         results[prop] = chain_array
     end
     # Add weights to dict
-    logweights = zeros(Float64, nchains, nsamples) # Matrix (nchain x nsample)
+    logweights = zeros(Float64, nchains, nsamples) # Matrix (nsample x nchain)
     for i_chain in 1:nchains
         for i_sample in 1:nsamples
             for dict_key in keys(loglikelihoods_cauchy)
-                logweights[i_chain, i_sample] += 
-                   loglikelihoods_normal[dict_key][i_sample, i_chain] - loglikelihoods_cauchy[dict_key][i_sample, i_chain]
+                logweights[i_sample, i_chain] += 
+                   loglikelihoods_normal[dict_key][i_chain, i_chain] - loglikelihoods_cauchy[dict_key][i_chain, i_chain]
             end
         end
     end
     logweights = logweights .- maximum(logweights) # set max weights = 1
-    # RTW something broke here
     weights = exp.(logweights)
     if (all(isfinite(weights)))
         results[:weights] = weights 

--- a/src/KickMCMC.jl
+++ b/src/KickMCMC.jl
@@ -61,18 +61,18 @@ function KickMCMC(; which_model, observations::Tuple{Observations, String}, prio
         chain_array = zeros(Float64, nsamples, nchains) # Matrix (nsample x nchain)
         for i_chain in 1:nchains
             for i_sample in 1:nsamples
-                chain_array[i_sample, i_chain] .= output_values[i_sample, i_chain][i_prop]
+                chain_array[i_sample, i_chain] = output_values[i_sample, i_chain][i_prop]
             end
         end
         results[prop] = chain_array
     end
     # Add weights to dict
-    logweights = zeros(Float64, nchains, nsamples) # Matrix (nsample x nchain)
+    logweights = zeros(Float64, nsamples, nchains) # Matrix (nsample x nchain)
     for i_chain in 1:nchains
         for i_sample in 1:nsamples
             for dict_key in keys(loglikelihoods_cauchy)
                 logweights[i_sample, i_chain] += 
-                   loglikelihoods_normal[dict_key][i_chain, i_chain] - loglikelihoods_cauchy[dict_key][i_chain, i_chain]
+                   loglikelihoods_normal[dict_key][i_sample, i_chain] - loglikelihoods_cauchy[dict_key][i_sample, i_chain]
             end
         end
     end

--- a/src/OutputStorage.jl
+++ b/src/OutputStorage.jl
@@ -26,7 +26,7 @@ end
 
 ##
 
-function ExtractResults(fname)
+function ExtractResults(fname;transpose_results=false)
     if ~isfile(fname)
         throw(ArgumentError("File not found"))
     end
@@ -35,6 +35,9 @@ function ExtractResults(fname)
     results = Dict()
     for key ∈ keys(extracted_results)
         results[Symbol(key)] = extracted_results[key][]
+        if(transpose_results && ndims(results[Symbol(key)])==2)
+            results[Symbol(key)] = transpose(results[Symbol(key)])
+        end
     end
     strings = fid["strings"]
     obs_string = strings["observations"][]


### PR DESCRIPTION
This decouples the corner plotting code to make it more general. New code also has a few fixes:

- correct problems with heatmap binning that led to bizarre crashes
- correct for missing fractions outside range
- allow access to any axis of the plot to add arbitrary elements
- simple interface to plot distributions on top of 1d marginalized distributions (ie for observations and priors)
- make the heatmap go from zero to the maximum, to prevent flat distributions from looking peaked